### PR TITLE
Update CreateConsoleServers_Template.json

### DIFF
--- a/LAB4-AzureTrafficManager/CreateConsoleServers_Template.json
+++ b/LAB4-AzureTrafficManager/CreateConsoleServers_Template.json
@@ -80,7 +80,7 @@
     "Windows": {
       "publisher": "MicrosoftWindowsServer",
       "offer": "WindowsServer",
-      "sku": "2019-Datacenter",
+      "sku": "2022-Datacenter",
       "version": "latest"
     },
     "imageReference": "[variables(parameters('OS'))]"


### PR DESCRIPTION
Change over to Server 2022 for the console servers.  This is due to the fact that Internet Explorer is going to be retiring.